### PR TITLE
 feat(logging): Console dependency replaced by action.

### DIFF
--- a/samples/Usage/Program.cs
+++ b/samples/Usage/Program.cs
@@ -22,7 +22,7 @@ namespace Usage
                         .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
                         .UseSimpleAssemblyNameTypeSerializer()
                         .UseRecommendedSerializerSettings()
-                        .UseCarbonAwareExecution(new CarbonAwareDataProviderOpenData(), ComputingLocations.Germany)
+                        .UseCarbonAwareExecution(new CarbonAwareDataProviderOpenData(), ComputingLocations.Germany, Console.WriteLine)
                         //.UseCarbonAwareExecution(
                         //    () => new CarbonAwareExecutionOptions(
                         //        new CarbonAwareDataProviderWattTime(userName, password), 

--- a/src/Hangfire.CarbonAwareExecution/CarbonAwareExecutionForecast.cs
+++ b/src/Hangfire.CarbonAwareExecution/CarbonAwareExecutionForecast.cs
@@ -5,7 +5,11 @@ namespace Hangfire.Community.CarbonAwareExecution;
 
 public class CarbonAwareExecutionForecast
 {
-    public static async Task<ExecutionTime> GetBestScheduleTime(DateTimeOffset earliestExecutionTime, DateTimeOffset latestExecutionTime, TimeSpan estimatedJobDuration)
+    public static Task<ExecutionTime> GetBestScheduleTime(
+        DateTimeOffset earliestExecutionTime,
+        DateTimeOffset latestExecutionTime,
+        TimeSpan estimatedJobDuration,
+        Action<string> logError)
     {
         try
         {
@@ -13,17 +17,17 @@ public class CarbonAwareExecutionForecast
             var options = filter?.Instance as CarbonAwareOptions;
             if (options == null)
             {
-                return ExecutionTime.NoForecast;
+                return Task.FromResult(ExecutionTime.NoForecast);
             }
 
             var provider = options.DataProvider;
             var location = options.ComputingLocation;
-            return await provider.CalculateBestExecutionTime(location, earliestExecutionTime, latestExecutionTime - estimatedJobDuration, estimatedJobDuration);
+            return provider.CalculateBestExecutionTime(location, earliestExecutionTime, latestExecutionTime - estimatedJobDuration, estimatedJobDuration);
         }
         catch (Exception ex)
         {
-            Console.WriteLine(ex.Message);
-            return ExecutionTime.NoForecast;
+            logError?.Invoke(ex.Message);
+            return Task.FromResult(ExecutionTime.NoForecast);
         }
     }
 }

--- a/src/Hangfire.CarbonAwareExecution/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.CarbonAwareExecution/GlobalConfigurationExtensions.cs
@@ -6,21 +6,22 @@ namespace Hangfire
 {
     public static class GlobalConfigurationExtensions
     {
-        public static IGlobalConfiguration UseCarbonAwareExecution(this IGlobalConfiguration configuration, CarbonAwareDataProvider dataProvider, ComputingLocation location)
+        public static IGlobalConfiguration UseCarbonAwareExecution( this IGlobalConfiguration configuration, CarbonAwareDataProvider dataProvider, ComputingLocation location, Action<string> logError)
         {
             var options = new CarbonAwareOptions(dataProvider, location);
 
             GlobalJobFilters.Filters.Add(options);
-            GlobalJobFilters.Filters.Add(new ShiftJobCarbonAwareFilter());
+            GlobalJobFilters.Filters.Add(new ShiftJobCarbonAwareFilter(logError));
             return configuration;
         }
-        public static IGlobalConfiguration UseCarbonAwareExecution(this IGlobalConfiguration configuration, Func<CarbonAwareExecutionOptions> configure)
+
+        public static IGlobalConfiguration UseCarbonAwareExecution(this IGlobalConfiguration configuration, Func<CarbonAwareExecutionOptions> configure, Action<string> logError)
         {
             var o = configure.Invoke();
             var options = new CarbonAwareOptions(o.DataProvider, o.Location);
 
             GlobalJobFilters.Filters.Add(options);
-            GlobalJobFilters.Filters.Add(new ShiftJobCarbonAwareFilter());
+            GlobalJobFilters.Filters.Add(new ShiftJobCarbonAwareFilter(logError));
             return configuration;
         }
     }

--- a/src/Hangfire.CarbonAwareExecution/ShiftJobCarbonAwareFilter.cs
+++ b/src/Hangfire.CarbonAwareExecution/ShiftJobCarbonAwareFilter.cs
@@ -2,14 +2,14 @@
 
 namespace Hangfire.Community.CarbonAwareExecution;
 
-public class ShiftJobCarbonAwareFilter() : ShiftJobFilter<CarbonAwareExecution>(GetUpdatedScheduleDate)
+public class ShiftJobCarbonAwareFilter(Action<string> logError) : ShiftJobFilter<CarbonAwareExecution>(GetUpdatedScheduleDate, logError)
 {
-    static ShiftedScheduleDate? GetUpdatedScheduleDate(CarbonAwareExecution execution)
+    static ShiftedScheduleDate? GetUpdatedScheduleDate(CarbonAwareExecution execution, Action<string> logError)
     {
         var now = DateTimeOffset.Now;
 
         return CarbonAwareExecutionForecast
-            .GetBestScheduleTime(now, now.Add(execution.MaxExecutionDelay), execution.EstimatedJobDuration)
+            .GetBestScheduleTime(now, now.Add(execution.MaxExecutionDelay), execution.EstimatedJobDuration, logError)
             .GetAwaiter().GetResult()
             .Match(
                 noForecast: _ => null,

--- a/src/Hangfire.CarbonAwareExecution/ShiftJobFilter.cs
+++ b/src/Hangfire.CarbonAwareExecution/ShiftJobFilter.cs
@@ -5,7 +5,9 @@ namespace Hangfire.Community.CarbonAwareExecution;
 
 public sealed record ShiftedScheduleDate(DateTimeOffset Date, string? Reason);
 
-public class ShiftJobFilter<TParameter>(Func<TParameter, ShiftedScheduleDate?> getShiftedScheduleDate) : IElectStateFilter
+public class ShiftJobFilter<TParameter>(
+    Func<TParameter, Action<string>, ShiftedScheduleDate?> getShiftedScheduleDate,
+    Action<string> logError) : IElectStateFilter
 {
     const string ShiftParameterName = "__Shift";
 
@@ -38,7 +40,7 @@ public class ShiftJobFilter<TParameter>(Func<TParameter, ShiftedScheduleDate?> g
             if (shiftParameter == null) //not yet shifted -> calculate shift and reschedule
             {
                 var now = DateTimeOffset.Now;
-                var delayedScheduleTime = getShiftedScheduleDate(delayParameter);
+                var delayedScheduleTime = getShiftedScheduleDate(delayParameter, logError);
 
                 if (delayedScheduleTime != null)
                 {


### PR DESCRIPTION
- The Console dependency in in CarbonAwareExecutionForecast was replaced  by "callback" the can be set from outside. Therefore errors can be  forwarded to different logging sinks.
- CarbonAwareExecutionForecast removed useless async/await.